### PR TITLE
Fix Update Task (`POST /api/tasks`)

### DIFF
--- a/src/io/orkes/api_client.clj
+++ b/src/io/orkes/api_client.clj
@@ -1,6 +1,7 @@
 (ns io.orkes.api-client
   (:require [cheshire.core :as json]
-            [org.httpkit.client :as http]))
+            [org.httpkit.client :as http]
+            [clojure.string :as str]))
 
 (def authorization-header-key "X-AUTHORIZATION")
 (def json-headers
@@ -62,7 +63,7 @@
                             :headers json-headers,
                             :body (json/generate-string body),
                             :query-params query-params,
-                            :url (str url resource "/" endpoint),
+                            :url (str url resource (when (not (str/blank? endpoint)) (str "/" endpoint)))
                             :as :text}]
       (make-request
         (if app-key


### PR DESCRIPTION
- The client is adding a trailing `"/"` to some resources like "/api/tasks/"-  This causes a 404
- Because of that 404 workers never complete a task.

<img width="1331" alt="Screenshot 2024-12-05 at 14 05 11" src="https://github.com/user-attachments/assets/696fe812-6b7e-442f-a082-53505308531f">
